### PR TITLE
Artifact and weapon bugfixes

### DIFF
--- a/src/StatStore.ts
+++ b/src/StatStore.ts
@@ -49,9 +49,9 @@ export const useStatStore = defineStore("stat", {
 
       const characterMult = characterStore.selectedCharacter.ascensionStat === LevelUpStat.DEFENSE ? characterStore.selectedStats.ascentionStatValue : 0;
       const weaponMult = weaponStore.selectedWeapon.subStat === LevelUpStat.DEFENSE ? weaponStore.selectedStats.subStatValue : 0;
-      const totalMult = (1 + characterMult + weaponMult + artifactStore.atkPerc);
+      const totalMult = (1 + characterMult + weaponMult + artifactStore.defPerc);
 
-      const flat = artifactStore.atkFlat;
+      const flat = artifactStore.defFlat;
 
       return (base * totalMult) + flat;
     },

--- a/src/artifact/components/ArtifactCirclet.vue
+++ b/src/artifact/components/ArtifactCirclet.vue
@@ -26,6 +26,7 @@ const mainstats = ref([
 const substats = [
     Stats.ENERGY_RECHARGE,
     Stats.HP_PERC,
+    Stats.HP_FLAT,
     Stats.ATTACK_FLAT,
     Stats.ATTACK_PERC,
     Stats.DEF_FLAT,

--- a/src/artifact/components/ArtifactGoblet.vue
+++ b/src/artifact/components/ArtifactGoblet.vue
@@ -25,6 +25,7 @@ const mainstats = ref([
 const substats = [
     Stats.ENERGY_RECHARGE,
     Stats.HP_PERC,
+    Stats.HP_FLAT,
     Stats.ATTACK_FLAT,
     Stats.ATTACK_PERC,
     Stats.DEF_FLAT,

--- a/src/artifact/components/ArtifactSands.vue
+++ b/src/artifact/components/ArtifactSands.vue
@@ -23,6 +23,7 @@ const mainstats = ref([
 const substats = [
     Stats.ENERGY_RECHARGE,
     Stats.HP_PERC,
+    Stats.HP_FLAT,
     Stats.ATTACK_FLAT,
     Stats.ATTACK_PERC,
     Stats.DEF_FLAT,

--- a/src/weapon/WeaponStore.ts
+++ b/src/weapon/WeaponStore.ts
@@ -5,7 +5,8 @@ import {WeaponType} from "../types/weaponType";
 import clamp from "../util/clamp";
 import getElem from "../util/getElem";
 import {Weapon, WeaponStats} from "../types/weapon";
-import { useStorage } from '@vueuse/core'
+import {useStorage} from "@vueuse/core";
+import {LevelUpStat} from "../types/levelUpStat";
 
 export const useWeaponStore = defineStore("weapon", {
   state: () => useStorage("weapon", {
@@ -13,10 +14,19 @@ export const useWeaponStore = defineStore("weapon", {
     selectedStatIndex: 0,
   }),
   getters: {
-    selectedWeapon: (state): Weapon => getElem(state.availableWeapons, state.selectedWeaponIndex),
-    selectedStats: (state): WeaponStats => getElem(state.selectedWeapon.stats, state.selectedStatIndex),
     availableWeapons: (): Weapon[] => {
-      return data[useCharacterStore().selectedCharacter.weapon ?? WeaponType.CATALYST]
+      return data[useCharacterStore().selectedCharacter.weapon] ?? [];
+    },
+    selectedWeapon: (state): Weapon => getElem(state.availableWeapons, state.selectedWeaponIndex) ?? {
+      name: "UNKNOWN",
+      subStat: -1 as LevelUpStat,
+      type: -1 as WeaponType,
+      stats: [],
+    },
+    selectedStats: (state): WeaponStats => getElem(state.selectedWeapon.stats, state.selectedStatIndex) ?? {
+      flatAttack: 0,
+      subStatValue: 0,
+      level: 0,
     },
   },
   actions: {


### PR DESCRIPTION
- HP_FLAT substat was not enabled for goblets, sands and circlets
- the def calculation used the artifact attack instead of def
- The weapon store did not provide a default for the selected weapon